### PR TITLE
feat: add path prefixes for routers

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -240,8 +240,9 @@ func (c *Cookie) GetName() string {
 type ServerSettings struct {
 	// The Address to listen on in the form of host:port
 	// See net.Dial for details of the address format.
-	Address string `yaml:"address" json:"address,omitempty" koanf:"address"`
-	Cors    Cors   `yaml:"cors" json:"cors,omitempty" koanf:"cors"`
+	Address    string `yaml:"address" json:"address,omitempty" koanf:"address"`
+	PathPrefix string `yaml:"path_prefix" json:"path_prefix,omitempty" koanf:"path_prefix" split_words:"true"`
+	Cors       Cors   `yaml:"cors" json:"cors,omitempty" koanf:"cors"`
 }
 
 type Cors struct {

--- a/backend/handler/admin_router.go
+++ b/backend/handler/admin_router.go
@@ -15,7 +15,11 @@ func NewAdminRouter(cfg *config.Config, persister persistence.Persister, prometh
 	e := echo.New()
 	e.Renderer = template.NewTemplateRenderer()
 	e.HideBanner = true
+
 	g := e.Group("")
+	if len(cfg.Server.Admin.PathPrefix) > 0 {
+		g = e.Group(cfg.Server.Admin.PathPrefix)
+	}
 
 	e.HTTPErrorHandler = dto.NewHTTPErrorHandler(dto.HTTPErrorHandlerConfig{Debug: false, Logger: e.Logger})
 	e.Use(middleware.RequestID())


### PR DESCRIPTION
Implements path prefixes for both public and admin routers so hanko can be hosted also on a subpath.

<!-- Thank you for submitting a pull request for this project! This is a pull request template,
please remove any sections that are not applicable. -->

# Description

<!-- Brief description of WHAT you’re doing and WHY. -->

<!-- If applicable, add references to fixed/related issues (e.g. add "Fixes #<issue>"/"Relates to#<issue>".  -->

# Implementation

<!-- Brief description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need
to refactor something? What tradeoffs did you take? Are there any caveats/downsides to your solution? Are there things
in here which you’d particularly like people to pay close attention to? -->

# Tests

<!-- Describe how to verify your changes. Provide instructions for the purpose of reproducibility. List any relevant
details for your test configuration. -->

# Todos

<!-- Are there any other outstanding issues or tasks that must be solved before this change can be possibly merged? -->

# Additional context

<!-- Add any other relevant context pertaining to the proposed change. For example, if the change can be visualized,
include screenshots or diagrams to indicate the state before and after the change. -->
